### PR TITLE
chore: migrate eligible workflows to ubuntu-slim runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   release:
     if: github.event.action != 'labeled'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -52,7 +52,7 @@ jobs:
 
   release-check:
     if: ${{ github.event.action == 'labeled' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Post bumpr status comment


### PR DESCRIPTION
## Summary
Ubuntu Slim Runner は軽量・低コストなランナーで、以下のような軽量ワークフロー向きです:
- release-please / PR タイトル検証 / claude-code / tag 自動化 / 軽量 Node CI 等

制約 (15分タイムアウト / unprivileged container / 最小プリインツール) に合致するワークフローのみ対象としています。Gradle/Rust/Go/Dart/fastlane 等の重量ビルドは対象外です。

### 変更対象
- `.github/workflows/release.yml` (release / release-check の 2 ジョブ両方)

### 調査の詳細
関連調査タスク: yshrsmz 配下リポジトリの Slim Runner 化可能性調査 (2026-04-15 完了)

## Test plan
- [ ] PR 作成後、対象ワークフローが push/label/issue 等のトリガーで正常に動作することを確認
- [ ] claude-code 系は `timeout-minutes: 15` に抵触しないかモニタリング