### PR TITLE
ci: serialize release workflow runs with concurrency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,12 @@
 name: release
+
+# Serialize release runs on the same ref so that near-simultaneous pushes
+# (e.g. multiple Renovate PRs merged at once) do not race. cancel-in-progress
+# is false to avoid aborting an in-flight release midway.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 on:
   push:
     branches:


### PR DESCRIPTION
## 背景

run [27064383746](https://github.com/yshrsmz/action-mise-values/actions/runs/27064383746) が `refusing to allow a GitHub App to create or update workflow ... without workflows permission` で失敗した。

原因は、Renovate の #21 (yq) と #20 (checkout) がほぼ同時にマージされ、#21 起因の release run が動いた時点で main HEAD が #20 まで進んでいたこと。bumpr が「最新でなくなった古いコミット」にタグを付けて `GITHUB_TOKEN` で push したため、GitHub の workflow 保護に弾かれた（古いコミット + `.github/workflows/` 配下のファイルが存在すると拒否される）。

## 変更

release ワークフローに `concurrency` を追加し、同一 ref への push run を直列化する。

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: false
```

- `cancel-in-progress: false`: 実行中のリリースを途中でキャンセルしないため。

## 注意（完全な再発防止ではない）

`concurrency` は run の重なりを制御するだけで、各 run が checkout する trigger SHA は変えられない。複数 PR が同時マージされた事実があると、古いコミットへのタグ付けは依然起こりうる。確実な再発防止が必要なら、別途以下を検討:

- bumpr / update-semver に PAT (`contents:write` + `workflows:write`) を渡す
- Renovate 側で同時マージを抑制（`prConcurrentLimit: 1` 等）

🤖 Generated with [Claude Code](https://claude.com/claude-code)