### PR TITLE
fix: use github.ref_name for tag name on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         uses: haya14busa/action-cond@94f77f7a80cd666cb3155084e428254fea4281fd # v1.2.1
         with:
           cond: "${{ startsWith(github.ref, 'refs/tags/') }}"
-          if_true: ${{ github.ref }}
+          if_true: ${{ github.ref_name }}
           if_false: ${{ steps.bumpr.outputs.next_version }}
 
       # Create release


### PR DESCRIPTION
## 背景

v0.3.0 を手動タグで切った際、GitHub Release のタイトルが `Release refs/tags/v0.3.0` となり、`refs/tags/` プレフィックスが混入した（タグ名 `v0.3.0` 自体は正常）。

通常の main push 経路では bumpr の `next_version`（`v0.3.0`）が使われるため発生せず、**tag push 経路を初めて通したことで露呈**した。

## 原因

`tag` ステップ（action-cond）の `if_true` がフル参照 `github.ref`（= `refs/tags/v0.3.0`）を返していた。

```yaml
if_true: ${{ github.ref }}   # refs/tags/v0.3.0
```

`gh release create "${TAG_NAME}"` は `refs/tags/` を剥がしてタグ名を解決するが、`-t "Release ${TAG_NAME}"` のタイトルは文字列そのままなのでプレフィックスが残った。

## 変更

`github.ref` → `github.ref_name`（= `v0.3.0`）に変更。タグ名・タイトルとも正しくなる。

なお、既に公開済みの v0.3.0 リリースのタイトルは手動で `Release v0.3.0` に修正済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)